### PR TITLE
gh-4: Uses yaml string literal to specify multiple container  tags in CI.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish container
-      uses: docker/build-and-push-action@v6
+      uses: docker/build-push-action@v6
       with:
         push: true
         tags: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,8 +35,8 @@ jobs:
       uses: docker/build-and-push-action@v6
       with:
         push: true
-        tags:
-          - ghcr.io/cycoresystems/audimance-demo:latest
-          - ghcr.io/cycoresystems/audimance-demo:${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        tags: |
+          ghcr.io/cycoresystems/audimance-demo:latest
+          ghcr.io/cycoresystems/audimance-demo:${{ github.ref_type == 'tag' && github.ref_name || '' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR addresses syntax and naming issues in the CI pipeline. Now it looks like it's failing for legit reasons: https://github.com/CyCoreSystems/audimance-demo/actions/runs/17081008922/job/48434621982